### PR TITLE
Ensure 'service.cpe23' contains '-' for no version

### DIFF
--- a/fingerprints.go
+++ b/fingerprints.go
@@ -160,6 +160,11 @@ func (fp *Fingerprint) Match(data string) *FingerprintMatch {
 				res.Errors = append(res.Errors, fmt.Errorf("param %s could not be substituted", rk))
 				return s
 			}
+			if strings.HasPrefix(v, "cpe:") && rk == "service.version" && r == "" {
+				// Ensure we follow the existing service.cpe23 format the recog project uses
+				// when 'service.version' isn't set/provided
+				return "-"
+			}
 			return r
 		})
 		res.Values[k] = nv


### PR DESCRIPTION
If `service.version` is not present/known for a fingerprint,
use a dash ('-') when filling out `service.cpe23` for the version
field, which matches the CPE interpolation behavior of the
ruby logic in the recog project.

Results of a match with and without service version using this
PR'd code:

```
$ echo "cpsrvd/11.44.3.0" | cmd/recog_match/recog_match pkg/nition/recog/xml
{"fp.certainty":"0.85","service.cpe23":"cpe:/a:cpanel:cpanel:11.44.3.0","service.product":"cPanel Service Daemon","service.vendor":"cPanel","service.version":"11.44.3.0"}

$ echo "cpsrvd" | cmd/recog_match/recog_match pkg/nition/recog/xml
{"fp.certainty":"0.85","service.cpe23":"cpe:/a:cpanel:cpanel:-","service.product":"cPanel Service Daemon","service.vendor":"cPanel","service.version":""}
```

Fixes #12