### PR TITLE
Fix user-supplied pattern/desc parsing

### DIFF
--- a/cmd/recog_match/main.go
+++ b/cmd/recog_match/main.go
@@ -28,13 +28,11 @@ func visit(files *[]string) filepath.WalkFunc {
 }
 
 func fingerprint(fingerprints []recog.FingerprintDB, text string) {
-	for _, term := range strings.Fields(text) {
-		for _, fdb := range fingerprints {
-			match := fdb.MatchFirst(term)
-			if match.Matched {
-				j, _ := json.Marshal(match.Values)
-				fmt.Printf("%s\n", j)
-			}
+	for _, fdb := range fingerprints {
+		match := fdb.MatchFirst(text)
+		if match.Matched {
+			j, _ := json.Marshal(match.Values)
+			fmt.Printf("%s\n", j)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #21.

`fingerprint()` was splitting the user-supplied pattern/description on spaces before comparing to recog fingerprints.

Example prior to this PR:

```
$ cd recog-go/cmd/recog_match
$ go run main.go /Users/userx/code/recog/xml/snmp_sysdescr.xml "Prestige 650R-T3"
$
$ go run main.go /Users/userx/code/recog/xml "Prestige 650R-T3"
$
$ go run main.go /Users/userx/code/recog/xml "Eltex - NTP-2"
$
```

Example with this PR:

```
$ cd recog-go/cmd/recog_match
$ go run main.go /Users/userx/code/recog/xml "Prestige 650R-T3"
{"fp.certainty":"0.85","matched":"ZxXEL Prestige 650R-T3 ADSL router","os.device":"Broadband Router","os.product":"Prestige 650R-T3","os.vendor":"Zyxel"}
$ go run main.go /Users/userx/code/recog/xml/snmp_sysdescr.xml "Prestige 650R-T3"
{"fp.certainty":"0.85","matched":"ZxXEL Prestige 650R-T3 ADSL router","os.device":"Broadband Router","os.product":"Prestige 650R-T3","os.vendor":"Zyxel"}
$ go run main.go /Users/userx/code/recog/xml "Eltex - NTP-2"
{"fp.certainty":"0.85","hw.cpe23":"cpe:/h:eltex-co:ntp-2:-","hw.device":"Broadband Router","hw.product":"NTP-2","hw.vendor":"Eltex","matched":"Eltex - NTP-2 broadband router","os.cpe23":"cpe:/o:eltex-co:ntp-2_firmware:-","os.device":"Broadband Router","os.product":"NTP-2 Firmware","os.vendor":"Eltex"}
```